### PR TITLE
Improve transaction termination for NCIP1 strict socket client

### DIFF
--- a/lib-ncip-client/src/main/java/org/olf/rs/circ/client/NCIP1Client.java
+++ b/lib-ncip-client/src/main/java/org/olf/rs/circ/client/NCIP1Client.java
@@ -124,6 +124,9 @@ public class NCIP1Client implements CirculationClient {
 					if( (firstRead == false && sleeps >= maxSleeps) || sleeps >= maxFirstSleeps) {
 						logger.info("Max time exceeded for waiting on server");
 						break;
+					} else if (firstRead == false && fromServer.ready() == false) {
+						logger.debug("Ready state changed to false post-read. Assuming complete.");
+						break;
 					} else {
 						//logger.info("Server is not ready to read");
 						Thread.sleep(sleepLength);


### PR DESCRIPTION
Currently, when the client reads the response of an NCIP1 server with a strict socket configuration it is blocked from getting to the break statement because the BufferedReader's `.ready()` method returns `false` before `.readLine()` can return null. Transactions must therefore always wait the maximum number of "sleeps" in this configuration. 

This proposed fix assumes that if the state changes to `.ready() == false` *after* reading has successfully started then it indicates that reading has ended and leaves the loop. 

Another alternative would be a nested do/while loop while .readLine() != null.